### PR TITLE
Add ability to search on a specific role name

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -28,5 +28,22 @@ platforms:
 
 suites:
 - name: default
-  run_list: []
-  attributes: {}
+  run_list:
+    - recipe[apt] # get updated package list for java
+    - recipe[java]
+    - recipe[cassandra-opscenter::default]
+    - role[cassandra-test-cluster]
+  attributes:
+    ec2:
+      public_hostname: localtest.me
+
+- name: non_first_role
+  run_list:
+    - recipe[apt]
+    - recipe[java]
+    - recipe[cassandra-opscenter::default]
+    - role[another-role]
+    - role[cassandra-test-cluster]
+  attributes:
+    ec2:
+      public_hostname: localtest.me

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -3,6 +3,11 @@ driver_plugin: vagrant
 driver_config:
   require_chef_omnibus: true
 
+provisioner:
+  name: chef_zero
+  client_rb:
+    ssl_verify_mode: :verify_none # Chef outputs an ugly SSL warning otherwise
+
 platforms:
 - name: ubuntu-12.04
   driver_config:

--- a/Berksfile
+++ b/Berksfile
@@ -1,1 +1,3 @@
-site :opscode
+source 'https://supermarket.getchef.com'
+
+metadata

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ This cookbook holds certain assumptions to be true in order to easily manage its
 ##### B) All members of the cluster share the same UNIQUE chef role and this is the first role in the list of roles. i.e. cassandra-cluster-one or product-production-casdb.
 ###### Reason: The unique role is used to search for other cluster members for shared information. If you want to extend/improve this please submit patches.
 
+Note: an attribute has been added that will allow you to specify the `role` you want to search on, it may not be the first one in the run list. Set `node[:cassandra][:opscenter][:cluster_role]` to your desired role name for this to work.
+
 ##### C) Connectivity between cluster members is suffiently open to allow for agent distribution and agent connectivity. Typically you should have a security group that allows relatively open access from that security group on port 80 for agent distrubtion.
 ###### Reason: Nothing will work without connectivity anyway. No node is an island.
 
@@ -91,5 +93,6 @@ Authors
 
 * Author: Alex Trull <atrull@mdsol.com>
 * Author: Benton Roberts <broberts@mdsol.com>
+* Author: Mike Fiedler <miketheman@gmail.com>
 
 Copyright: 2013–2013 Medidata Solutions, Inc.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -38,4 +38,5 @@ default[:cassandra][:opscenter][:server_port] = "8888"
 # This attribute can be used to force SSL agent communications. YMMV. default off.
 default[:cassandra][:opscenter][:use_ssl] = "0"
 
-
+# Role name for this cluster to search for. Defaults to first role on node.
+default[:cassandra][:opscenter][:cluster_role] = nil

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -19,11 +19,18 @@
 
 ## Simplistic leader election
 node.save
-peers = search(:node, "roles:#{node[:roles].first}" )
+# Find peers based on an attribute, fall back to the first role in on this node
+if node[:cassandra][:opscenter][:cluster_role]
+  peer_search_role = node[:cassandra][:opscenter][:cluster_role]
+else
+  peer_search_role = node[:roles].first
+end
+
+peers = search(:node, "roles:#{peer_search_role}" )
 leader = peers.sort{|a,b| a.name <=> b.name}.first || node # the "or" covers the case where node is the first db
 
 # Some reporting on the election
-Chef::Log.info("cassandra-opscenter LeaderElection: #{node[:roles].first} Leader is : #{leader.name} #{leader.ec2.public_hostname} #{leader.ipaddress}")
+Chef::Log.info("cassandra-opscenter LeaderElection: #{peer_search_role} Leader is : #{leader.name} #{leader.ec2.public_hostname} #{leader.ipaddress}")
 
 # Set some global vars to be used in the agent recipe
 $LEADERNAME = leader.name

--- a/test/integration/default/serverspec
+++ b/test/integration/default/serverspec
@@ -1,0 +1,1 @@
+../shared/serverspec/

--- a/test/integration/nodes/another-node.json
+++ b/test/integration/nodes/another-node.json
@@ -1,0 +1,9 @@
+{
+  "id": "another-node",
+  "run_list": [
+    "role[another-role]"
+  ],
+  "automatic": {
+    "ipaddress": "0.1.2.3"
+  }
+}

--- a/test/integration/non_first_role/serverspec
+++ b/test/integration/non_first_role/serverspec
@@ -1,0 +1,1 @@
+../shared/serverspec/

--- a/test/integration/roles/another-role.json
+++ b/test/integration/roles/another-role.json
@@ -1,0 +1,10 @@
+{
+  "name": "another-role",
+  "description": "Runs nothing",
+  "json_class": "Chef::Role",
+  "default_attributes": {},
+  "override_attributes": {},
+  "chef_type": "role",
+  "run_list": [],
+  "env_run_lists": {}
+}

--- a/test/integration/roles/cassandra-test-cluster.json
+++ b/test/integration/roles/cassandra-test-cluster.json
@@ -1,0 +1,10 @@
+{
+  "name": "cassandra-test-cluster",
+  "description": "Runs cassandra",
+  "json_class": "Chef::Role",
+  "default_attributes": {},
+  "override_attributes": {},
+  "chef_type": "role",
+  "run_list": [],
+  "env_run_lists": {}
+}

--- a/test/integration/shared/serverspec/default_spec.rb
+++ b/test/integration/shared/serverspec/default_spec.rb
@@ -1,0 +1,8 @@
+require 'serverspec'
+
+include Serverspec::Helper::Exec
+include Serverspec::Helper::DetectOS
+
+describe service('datastax-agent') do
+  it { should be_running }
+end


### PR DESCRIPTION
This adds a new attribute to allow search on a role that is not the
first one in a node's run list.

Fixes atrull/cassandra_opscenter_cookbook#2
- update Berksfile for supermarket and metadata load
- introduce chef-zero as the test-kitchen provisioner
- add test suites and supporting objects
- README update for role search
